### PR TITLE
LinuxMint 11 support and "no distro" detection

### DIFF
--- a/tasks/lib/distros.rb
+++ b/tasks/lib/distros.rb
@@ -17,6 +17,8 @@ def detect_distro
     info = Hash[ *File.new('/etc/lsb-release').lines.map{ |x| x.split('=').map { |y| y.chomp } }.flatten ]
     if info['DISTRIB_ID'] == 'Ubuntu'
       return [:ubuntu, info['DISTRIB_RELEASE']]
+    elsif info['DISTRIB_ID'] == 'LinuxMint'
+      return [:ubuntu, info['DISTRIB_RELEASE']]
     end
   end
 
@@ -72,5 +74,5 @@ def detect_distro
     end
   end
 
-  nil
+  raise StandardError, 'could not find distribution, maybe your OS isn\'t supported'
 end


### PR DESCRIPTION
added support for LinuxMint and tested install on LinuxMint 11 (gnome)
also made it raise an error if no distro detected
