### PR TITLE
Problem with building curl on Mac OS Snow Leopard.

### DIFF
--- a/tasks/lib.rb
+++ b/tasks/lib.rb
@@ -281,7 +281,7 @@ def configure_cmd(source, opts={})
   end
 
   ldflags = libs.map do |lib|
-    if DISTRO[0] == :osx && /^11\.\d+\./.match(DISTRO[1]) # 11.*
+    if DISTRO[0] == :osx && /^11\.\d+\.|^10\.8\./.match(DISTRO[1]) # 11.*
       "-L#{lib}"                        # llvm in OS X Lion
     else
       "-Xlinker -rpath=#{lib} -L#{lib}" # GCC


### PR DESCRIPTION
curl was failing due to some unsupported param falling through to default GCC.  Modified so it detects OS X 10.8.x too.
