### PR TITLE
Use zlib1g-dev (real package name) instead of libz-dev (virtual package name) on Ubuntu

### DIFF
--- a/tasks/all.rake
+++ b/tasks/all.rake
@@ -55,7 +55,7 @@ namespace :build do
   task :ubuntu_dependencies => :known_distro do
     if DISTRO[0] == :ubuntu
       # For building OTP
-      install_packages %w[ flex dctrl-tools libsctp-dev ed libz-dev ]
+      install_packages %w[ flex dctrl-tools libsctp-dev ed zlib1g-dev ]
 
       # All Ubuntu gets these.
       install_packages %w[ libxslt1-dev automake make ruby libtool g++ ]


### PR DESCRIPTION
Changing to use the real package name, zlib1g-dev, instead of libz-dev, which is the virtual package name.

If the zlib is already installed, build will fail because libz-dev cannot be detected using dpkg --list.
