### PR TITLE
Wrong ubuntu Z library

### DIFF
--- a/tasks/all.rake
+++ b/tasks/all.rake
@@ -55,7 +55,7 @@ namespace :build do
   task :ubuntu_dependencies => :known_distro do
     if DISTRO[0] == :ubuntu
       # For building OTP
-      install_packages %w[ flex dctrl-tools libsctp-dev ed libz-dev ]
+      install_packages %w[ flex dctrl-tools libsctp-dev ed zlib1g-dev ]
 
       # All Ubuntu gets these.
       install_packages %w[ libxslt1-dev automake make ruby libtool g++ ]


### PR DESCRIPTION
When setting up the library dependencies in the rake task the ubuntu list includes libz-dev which is incorrect, and causes the build to fail when running unattended and without sudo.  

This change is just shifting it over to the correct dependency for ubuntu of, zlib1g-dev.
