### PR TITLE
remove libz-dev from Ubuntu install_packages. It is already a listed pre...

### DIFF
--- a/tasks/all.rake
+++ b/tasks/all.rake
@@ -55,7 +55,7 @@ namespace :build do
   task :ubuntu_dependencies => :known_distro do
     if DISTRO[0] == :ubuntu
       # For building OTP
-      install_packages %w[ flex dctrl-tools libsctp-dev ed libz-dev ]
+      install_packages %w[ flex dctrl-tools libsctp-dev ed ]
 
       # All Ubuntu gets these.
       install_packages %w[ libxslt1-dev automake make ruby libtool g++ ]


### PR DESCRIPTION
It is already a listed pre...-req in the readme (by another name) and causes rake to need sudo privileges.
