### PR TITLE
Replacing git:// scheme with https://

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
         url = https://git-wip-us.apache.org/repos/asf/couchdb.git
 [submodule "dependencies/otp"]
 	path = dependencies/otp
-	url = git://github.com/erlang/otp.git
+	url = https://github.com/erlang/otp.git
 [submodule "dependencies/curl"]
 	path = dependencies/curl
-	url = git://github.com/bagder/curl.git
+	url = https://github.com/bagder/curl.git


### PR DESCRIPTION
Hello,

I know it's not an important requirement, though this allows people in a restricted network configuration (allowing only access to http/https for instance) to checkout recursively everything needed to build couch using your great wrapper.

Thanks in advance.
