### PR TITLE
updated tasks/lib/distros.rb for scienfic linux

### DIFF
--- a/tasks/lib/distros.rb
+++ b/tasks/lib/distros.rb
@@ -60,7 +60,7 @@ def detect_distro
       raise 'Version of ruby is too old. Consider installing a more recent version'
     end
 
-    release = File.new('/etc/redhat-release').readline.match(/Scientific Linux SLF release (\d+)/)[1]
+    release = File.new('/etc/redhat-release').readline.match(/Scientific Linux release \d.\d \([A-z][a-z]+\)/)[1]
     return [:slf, release]
   end
 


### PR DESCRIPTION
Similar to this [issue](https://github.com/iriscouch/build-couchdb/pull/31), there is a problem with `build-couchdb/tasks/lib/distros.rb` whereby it has failed to parse `/etc/redhat-release` file. This is because the script parses versions of Scientific Linux (pre 6.0), that has a pattern

    Scientific Linux SLF release (5.0) 

However since 6.0 they have adopted the following pattern:

    Scientific Linux release 6.2 (Carbon) 

See [this](https://cfengine.com/bugtracker/bug_view_advanced_page.php?bug_id=570)
