### PR TITLE
dependencies missing for Ubuntu 12.0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ On **Debian**, first install `sudo` and add yourself to `/etc/sudoers`.
 
 On **Ubuntu and Debian**:
 
-    sudo apt-get install help2man make gcc zlib1g-dev libssl-dev rake help2man texinfo
+    sudo apt-get install help2man make gcc zlib1g-dev libssl-dev rake help2man texinfo 
+    sudo apt-get -y install dctrl-tools libsctp-dev ed libxslt1-dev libcap2-bin automake
 
 On **OpenSUSE**:
 


### PR DESCRIPTION
Hi.

Tried to build on a brand new LXC Container running  Ubuntu 12.0.4 . 
Had to the following : 
dctrl-tools 
libsctp-dev 
ed 
libxslt1-dev 
libcap2-bin 
automake
